### PR TITLE
Connector execution

### DIFF
--- a/app/dao/mapperDAO.js
+++ b/app/dao/mapperDAO.js
@@ -9,9 +9,16 @@
 
       this.public = {
         create: function createMap(name, maps) {
+          var filledMaps = [];
+          maps.forEach(function checkMap(map) {
+            console.log(map);
+            if (!!map.place && !!map.source && !!map.destination) {
+              this.push(map);
+            }
+          }, filledMaps);
           return this.private.request('POST', '/api/mappers/', {
             name: name,
-            maps: maps
+            maps: filledMaps
           });
         },
         getAll: function getAll() {

--- a/app/widgets/mapperRegistrator/mapperRegistrator.html
+++ b/app/widgets/mapperRegistrator/mapperRegistrator.html
@@ -39,6 +39,7 @@
     </section>
     <md-button class="md-primary md-raised"
                aria-label="save map"
+               type="submit"
                ng-click="save()">
       save
     </md-button>

--- a/app/widgets/mapperRegistrator/mapperRegistrator.js
+++ b/app/widgets/mapperRegistrator/mapperRegistrator.js
@@ -15,7 +15,7 @@
 
         scope.$watch('maps', function autoAdd(newMaps) {
           var lastMap = newMaps[newMaps.length - 1];
-          if (!!lastMap.source && !!lastMap.destination) {
+          if (!!lastMap.place && !!lastMap.source && !!lastMap.destination) {
             scope.addMap();
           }
         }, true);

--- a/app/widgets/selector/selector.html
+++ b/app/widgets/selector/selector.html
@@ -6,8 +6,9 @@
 <md-text-float label="{{ label }}"
                ng-model="displayValue"
                ng-click="openOptions()"></md-text-float>
-<md-whiteframe class="md-whiteframe-z5">
-  <md-list ng-show="isOpen">
+<md-whiteframe class="md-whiteframe-z5"
+               ng-show="isOpen">
+  <md-list>
     <md-item flex ng-repeat="option in options"
              ng-click="select(option)">
       <ng-transclude></ng-transclude>

--- a/server/api.js
+++ b/server/api.js
@@ -142,7 +142,7 @@
         res.send(data);
         return data;
       }, function error(err) {
-        res.status(500).send(err);
+        res.status(500).send(err.toString());
         throw err;
       });
   }

--- a/server/api.js
+++ b/server/api.js
@@ -171,7 +171,8 @@
       headers: headers,
       agentOptions: {
         ca: config.getCertificates()
-      }
+      },
+      strictSSL: false
     };
 
     var type = apiCall.type || null;

--- a/server/mapper.js
+++ b/server/mapper.js
@@ -54,19 +54,19 @@
 
     var obj = {};
     var parts = map.split('.');
-    for (var i = parts.length -1; i >= 0; i--) {
+    for (var i = parts.length - 1; i >= 0; i--) {
       var part = parts[i];
 
       var newObj = {};
       //create indexed array if part is numeric
-      if(!isNaN(part)) {
+      if (!isNaN(part)) {
         newObj = [];
         part = parseInt(part, 10);
       }
 
 
       // the deepest key holds the value
-      if(i === parts.length - 1) {
+      if (i === parts.length - 1) {
         newObj[part] = value;
       } else {
         newObj[part] = obj;
@@ -98,7 +98,7 @@
   function modifyCall(call, mappedValues) {
     for (var i = 0; i < mappedValues.length; i++) {
       var mappedValue = mappedValues[i];
-      switch(mappedValue.place) {
+      switch (mappedValue.place) {
         case 'url':
           var regex = new RegExp(mappedValue.destination, 'g');
           var url = call.url.replace(regex, mappedValue.value);
@@ -109,13 +109,13 @@
         case 'header':
           var additionalData = createObjectFromMap(mappedValue.destination, mappedValue.value);
 
-          if(mappedValue.place === 'data') {
-            if(!!!call.data) {
+          if (mappedValue.place === 'data') {
+            if (!!!call.data) {
               call.data = {};
             }
             call.data = _.extend(call.data, additionalData);
           } else {
-            if(!!!call.headers) {
+            if (!!!call.headers) {
               call.headers = {};
             }
             call.headers = _.extend(call.headers, additionalData);

--- a/server/resources/Mapper.js
+++ b/server/resources/Mapper.js
@@ -11,9 +11,18 @@
   var mapperSchema = new Schema({
     name: String,
     maps: [{
-      place: String,
-      source: String,
-      destination: String
+      place: {
+        type: String,
+        required: true
+      },
+      source: {
+        type: String,
+        required: true
+      },
+      destination: {
+        type: String,
+        required: true
+      }
     }]
   });
 

--- a/server/server.js
+++ b/server/server.js
@@ -3,7 +3,8 @@
 //
 // Author: Andy Tang
 // Fork me on Github: https://github.com/EnoF/con-rest
-(function serverScope(express, bodyParser, api, workflow, mongoose, params, execution, workflowExecution, connector, config,
+(function serverScope(express, bodyParser, api, workflow, mongoose, params, execution, workflowExecution, connector,
+  config,
   mapper) {
   'use strict';
 
@@ -17,7 +18,7 @@
   mongoose.connect(connect.uri, connect.options);
 
   var db = mongoose.connection;
-  db.on('error', console.error);
+  db.on('error', console.log);
   db.once('open', function initiateServer() {
     app.param('id', String);
 

--- a/server/workflow.js
+++ b/server/workflow.js
@@ -86,7 +86,8 @@
             res.send(results);
           });
       }, function error(err) {
-        if(res.status) {
+        if (res.status) {
+          console.log(err.toString());
           res.status(500).send(err.toString());
         }
         throw err;

--- a/test/unit/app/viewModels/mapperCSpecs.js
+++ b/test/unit/app/viewModels/mapperCSpecs.js
@@ -23,7 +23,7 @@
       $scope.maps = [{
         place: 'banana',
         source: 'foo',
-        destionation: 'bar'
+        destination: 'bar'
       }];
 
       // predict

--- a/test/unit/app/widgets/mapperRegistratorWidgetSpecs.js
+++ b/test/unit/app/widgets/mapperRegistratorWidgetSpecs.js
@@ -2,13 +2,14 @@
   'use strict';
 
   describe('<mapper-registrator> specs', function mapperRegistratorSpecs() {
-    var testGlobals, parentScope;
+    var testGlobals, parentScope, $httpBackend;
 
     beforeEach(module('con-rest-test'));
 
     beforeEach(inject(function setupTest(testSetup) {
       testGlobals = testSetup.setupDirectiveTest();
       parentScope = testGlobals.parentScope;
+      $httpBackend = testGlobals.$httpBackend;
     }));
 
     it('should add a default map to the maps', defaultMap);
@@ -28,13 +29,16 @@
       return $scope;
     }
 
-    it('should automatically add a new map', function autoAdd() {
+    it('should automatically add a new map', autoAdd);
+
+    function autoAdd() {
       // given
       var $scope = defaultMap();
 
       // when
-      $scope.maps[0].source = 'something';
-      $scope.maps[0].destination = 'something';
+      $scope.maps[0].place = 'data';
+      $scope.maps[0].source = 'foo';
+      $scope.maps[0].destination = 'bar';
       expect($scope.maps.length).toEqual(1);
       $scope.$digest();
 
@@ -43,6 +47,32 @@
         source: null,
         destination: null
       }));
+      expect($scope.maps.length).toEqual(2);
+      return $scope;
+    }
+
+    it('should only submit the filled in maps', function filledInMaps() {
+      // given
+      var $scope = autoAdd();
+      $scope.name = 'test';
+
+      // predict
+      $httpBackend.expect('POST', '/api/mappers/', {
+          name: 'test',
+          maps: [{
+            place: 'data',
+            source: 'foo',
+            destination: 'bar'
+          }]
+        })
+        .respond(200, 'ok');
+
+      // when
+      $scope.save();
+      $httpBackend.flush();
+
+      // then
+      expect($scope.maps.length).toEqual(1);
     });
   });
 }(window.angular));

--- a/test/unit/server/mapperSpecs.js
+++ b/test/unit/server/mapperSpecs.js
@@ -83,6 +83,7 @@
             body: {
               name: 'fake mapper',
               maps: [{
+                place: 'data',
                 source: 'test.data',
                 destination: 'testData'
               }]
@@ -345,12 +346,9 @@
         expect(result).to.deep.equal({
           a: [
             [
-              [
-                ,
-                {
-                  b: 1337
-                }
-              ]
+              [, {
+                b: 1337
+              }]
             ]
           ]
         });


### PR DESCRIPTION
Fixed the mapper widget to not submit empty maps. This caused the connector to fail. 

Also the backend side of the mapper widget will now prevent saving of empty maps.

This was found during testing of PR #70
